### PR TITLE
Add build support for Linux environment with CMake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings/
 /Debug
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(CMAKE_TOOLCHAIN_FILE ../arm_toolchain.cmake)
+
+# プロジェクトの基本設定
+project(try-kernel C CXX ASM)
+set(CMAKE_C_STANDARD 11)   # C言語の規格=C11
+set(CMAKE_CXX_STANDARD 17) # C++言語の規格=C++17
+
+# ソースコードの追加
+add_executable(try-kernel
+    application/gsns.c
+    application/lcd.c
+    application/lsns.c
+    application/usermain.c
+    boot/boot2.c
+    boot/reset_hdr.c
+    boot/vector_tbl.c
+    device/adc/adc_rp2040.c
+    device/devmgr/device_tbl.c
+    device/devmgr/device.c
+    device/i2c/i2c_rp2040.c
+    kernel/context.c
+    kernel/eventflag.c
+    kernel/inittsk.c
+    kernel/scheduler.c
+    kernel/semaphore.c
+    kernel/syslib.c
+    kernel/systimer.c
+    kernel/task_mange.c
+    kernel/task_queue.c
+    kernel/task_sync.c
+    kernel/dispatch.S
+)
+
+# Add include directory
+target_include_directories(try-kernel PRIVATE include)
+target_link_options(try-kernel PRIVATE -T ${CMAKE_SOURCE_DIR}/linker/pico_memmap.ld)
+set_target_properties(${TARGET_NAME} PROPERTIES LINK_DEPENDS linker/pico_memmap.ld)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,7 +32,7 @@ cmake ..
 make -j`nproc`
 ```
 
-ビルドに成功すれば、 `part_5/build/try-kernel` にELF形式のバイナリが出力されるので、pico-toolなどで書き込む。
+ビルドに成功すれば、 `build/try-kernel` にELF形式のバイナリが出力されるので、pico-toolなどで書き込む。
 
 ```
 pico-tool load -x -t elf try-kernel

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,6 +14,30 @@ Try Kernelは、CQ出版(株) Interface 2023年7月号の特集「ゼロから�
 - Eclipse IDE for Embedded C/C++ Developers
 - GNU Arm Embedded GCC
 
+## Linux環境でのビルド
+
+現在のところ、 `part_5` のソースコードのみCMakeでのビルドプロジェクトが用意されており、CMakeおよびGCCでのLinux環境上でのビルドが可能である。
+
+ビルドに必要なパッケージを以下のコマンドでインストールする。
+
+```
+sudo apt install -y cmake gcc-arm-none-eabi gdb-multiarch
+```
+
+その後、本リポジトリをcloneしたディレクトリで以下のコマンドを実行する。
+
+```
+mkdir -p build; cd $_
+cmake ..
+make -j`nproc`
+```
+
+ビルドに成功すれば、 `part_5/build/try-kernel` にELF形式のバイナリが出力されるので、pico-toolなどで書き込む。
+
+```
+pico-tool load -x -t elf try-kernel
+```
+
 ## ライセンスについて
 
 本プログラムはMITライセンスの下でオープンソースとして公開します。著作権および許諾表示を記載すれば、非営利、商用を問わず、使用、改変、複製、再頒布が可能な制限の緩いライセンスですので、本プログラムをOSの自作に活用いただけたらと思います。ライセンスの詳細については、同梱のLICENSEをご参照ください。  

--- a/arm_toolchain.cmake
+++ b/arm_toolchain.cmake
@@ -1,0 +1,19 @@
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+set(CMAKE_FIND_ROOT_PATH /usr/lib/arm-none-eabi)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(COMMON_FLAGS "-Os -g -mthumb -march=armv6-m -fno-builtin -Wall -ffunction-sections -fdata-sections -fomit-frame-pointer -mabi=aapcs")
+set(CMAKE_C_FLAGS   "${COMMON_FLAGS}" CACHE INTERNAL "C Compiler Options")
+set(CMAKE_CXX_FLAGS "${COMMON_FLAGS}" CACHE INTERNAL "C++ Compiler Options")
+set(CMAKE_ASM_FLAGS "${COMMON_FLAGS}" CACHE INTERNAL "ASM Compiler Options")
+
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections --specs=nosys.specs -nostartfiles -mthumb -march=armv6-m -mabi=aapcs -Wl,-Map=${CMAKE_PROJECT_NAME}.map" CACHE INTERNAL "Linker Options")

--- a/device/devmgr/device_tbl.c
+++ b/device/devmgr/device_tbl.c
@@ -1,7 +1,7 @@
 ﻿#include <trykernel.h>
 #include "device.h"
-#include "..\i2c\dev_i2c.h"
-#include "..\adc\dev_adc.h"
+#include "../i2c/dev_i2c.h"
+#include "../adc/dev_adc.h"
 
 /* デバイス登録テーブル*/
 T_DEV_DEF   dev_tbl[DEV_NUM] = {


### PR DESCRIPTION
Linux (Ubuntu 22.04) 上で、CMakeをつかったビルド手順を追加してみました。