### PR TITLE
Fix build for cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request: {}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - run: sudo apt install -y cmake gcc-arm-none-eabi gdb-multiarch
+    - run: cmake -B build -S .
+    - run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(try-kernel
     kernel/eventflag.c
     kernel/gpio.c
     kernel/inittsk.c
+    kernel/interrupt.c
     kernel/messagebuf.c
     kernel/scheduler.c
     kernel/semaphore.c


### PR DESCRIPTION
Seems `kernel/interrupt.c` is missing in `add_executable`
https://github.com/take-cheeze/trykernel/actions/runs/19094991311/job/54552852759?pr=2 succeded